### PR TITLE
Changed to https to negate http 301 error & fixed typo on guildList()

### DIFF
--- a/class.wynncraftAPI.php
+++ b/class.wynncraftAPI.php
@@ -15,7 +15,7 @@ class wynncraftAPI
      *
      * @const string
      */
-    const apiUrl = 'http://api.wynncraft.com/public_api.php?';
+    const apiUrl = 'https://api.wynncraft.com/public_api.php?';
 
     /**
      * The format the api call should be returned as
@@ -165,7 +165,7 @@ class wynncraftAPI
      * @return array|mixed|string
      * @throws Exception
      */
-    public function guildList()) {
+    public function guildList() {
         return $this->apiCommand('guildList');
     }
 


### PR DESCRIPTION
Hi, there were just a couple things that made this API unusable.  Firstly, not using https resulted in a site moved response and secondly, guildList() had a missing bracket or something like that.  I may upload my caching system if it holds up.

Thanks!  --Romaine
